### PR TITLE
Ensure resource paths resolve correctly

### DIFF
--- a/PixelPruner.py
+++ b/PixelPruner.py
@@ -16,7 +16,7 @@ def resource_path(relative_path):
         # PyInstaller creates a temp folder and stores path in _MEIPASS
         base_path = sys._MEIPASS
     except Exception:
-        base_path = os.path.abspath(".")
+        base_path = os.path.abspath(os.path.dirname(__file__))
     
     return os.path.join(base_path, relative_path)
 


### PR DESCRIPTION
## Summary
- fix `resource_path` so resources are found when running outside repo directory

## Testing
- `python -m py_compile PixelPruner.py`


------
https://chatgpt.com/codex/tasks/task_e_6843719230748327a16877ce23dd9b13