### PR TITLE
Fix navigation crash when image list is empty

### DIFF
--- a/PixelPruner.py
+++ b/PixelPruner.py
@@ -500,6 +500,11 @@ class PixelPruner:
         if not self.folder_path and not self.images:
             self.show_info_message("Information", "Please set an Input Folder from the File Menu!")
             return
+
+        if not self.images:
+            self.show_info_message("Information", "No images loaded.")
+            return
+
         self.image_index = (self.image_index + 1) % len(self.images)
         self.load_image()
 
@@ -507,6 +512,11 @@ class PixelPruner:
         if not self.folder_path and not self.images:
             self.show_info_message("Information", "Please set an Input Folder from the File Menu!")
             return
+
+        if not self.images:
+            self.show_info_message("Information", "No images loaded.")
+            return
+
         self.image_index = (self.image_index - 1) % len(self.images)
         self.load_image()
 


### PR DESCRIPTION
## Summary
- handle empty image lists when navigating

## Testing
- `python -m py_compile PixelPruner.py`

------
https://chatgpt.com/codex/tasks/task_e_68436e74e82c83278ea3f618d4900ea5