### PR TITLE
Add crop-only analysis and UI improvements

### DIFF
--- a/pruneriq.py
+++ b/pruneriq.py
@@ -111,6 +111,8 @@ def analyze_image(image_path):
 def analyze_folder(folder_path):
     results = []
     for file in os.listdir(folder_path):
+        if not file.lower().startswith('cropped_'):
+            continue
         if file.lower().endswith(('.png', '.jpg', '.jpeg', '.webp')):
             image_path = os.path.join(folder_path, file)
             result = analyze_image(image_path)


### PR DESCRIPTION
## Summary
- only analyze files starting with `cropped_` in PrunerIQ
- add a loading dialog when launching PrunerIQ analysis
- provide a scrollbar for the results table

## Testing
- `python -m py_compile PixelPruner.py pruneriq.py`

------
https://chatgpt.com/codex/tasks/task_e_6844872f85008327af8c97dc536991ee