### PR TITLE
Add optional crops-only analysis

### DIFF
--- a/PixelPruner.py
+++ b/PixelPruner.py
@@ -898,14 +898,14 @@ class PixelPruner:
 
         loading = tk.Toplevel(self.master)
         loading.title("Please Wait")
-        tk.Label(loading, text="Analyzing crops...").pack(padx=20, pady=20)
+        tk.Label(loading, text="Analyzing images...").pack(padx=20, pady=20)
         loading.update()
 
         results = []
 
         def run_analysis():
             nonlocal results
-            results = analyze_folder(folder)
+            results = analyze_folder(folder, True)
             self.master.after(0, finish)
 
         def finish():
@@ -920,7 +920,7 @@ class PixelPruner:
         if not results:
             self.show_info_message(
                 "Analysis",
-                "No valid crops were found in the selected output folder.",
+                "No valid images were found in the selected output folder.",
             )
             return
 
@@ -942,16 +942,23 @@ class PixelPruner:
 
         path_frame = tk.Frame(window)
         path_frame.pack(fill=tk.X, padx=5, pady=5)
-        tk.Label(path_frame, text="Analyzing Crops in:").pack(side=tk.LEFT)
+        tk.Label(path_frame, text="Analyzing Images in:").pack(side=tk.LEFT)
         tk.Label(path_frame, textvariable=path_var, anchor="w").pack(
             side=tk.LEFT, fill=tk.X, expand=True
         )
+
+        crops_only_var = tk.BooleanVar(value=True)
+        tk.Checkbutton(
+            path_frame,
+            text="Crops Only",
+            variable=crops_only_var,
+        ).pack(side=tk.RIGHT, padx=5)
 
         def run_analysis(path):
             nonlocal all_results, current_folder
             current_folder = path
             path_var.set(path)
-            all_results = analyze_folder(path)
+            all_results = analyze_folder(path, crops_only_var.get())
             populate_tree(all_results)
             update_summary()
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ PixelPruner is a user-friendly image cropping app for AI-generated art. It suppo
 - **Undo Crop Actions**: Made a mistake? Simply undo the last crop with the click of a button.
 
 - **Keyboard Shortcuts**: Navigate and manipulate images effortlessly with convenient WASD keyboard shortcuts.
+- **Flexible Analysis**: The PrunerIQ window includes a `Crops Only` checkbox so
+  you can analyze either just the cropped images or all images in a folder.
 
 ### PrunerIQ Metrics
 

--- a/pruneriq.py
+++ b/pruneriq.py
@@ -108,12 +108,28 @@ def analyze_image(image_path):
         "reason": reason
     }
 
-def analyze_folder(folder_path):
+def analyze_folder(folder_path, crops_only=True):
+    """Analyze images in ``folder_path``.
+
+    Parameters
+    ----------
+    folder_path : str
+        Directory containing images to analyze.
+    crops_only : bool, optional
+        If ``True`` only files whose names start with ``"cropped_"`` will be
+        processed.  When ``False`` all supported image files are analyzed.
+
+    Returns
+    -------
+    list[dict]
+        A list of metric dictionaries for each image.
+    """
+
     results = []
     for file in os.listdir(folder_path):
-        if not file.lower().startswith('cropped_'):
+        if crops_only and not file.lower().startswith("cropped_"):
             continue
-        if file.lower().endswith(('.png', '.jpg', '.jpeg', '.webp')):
+        if file.lower().endswith((".png", ".jpg", ".jpeg", ".webp")):
             image_path = os.path.join(folder_path, file)
             result = analyze_image(image_path)
             results.append(result)


### PR DESCRIPTION
## Summary
- support analyzing full folders or just crops
- expose a `Crops Only` checkbox in the PrunerIQ window
- document flexible analysis mode in README

## Testing
- `python3 -m py_compile PixelPruner.py pruneriq.py`

------
https://chatgpt.com/codex/tasks/task_e_68448a8cb5d88327a7a9bfab6bcd44e4